### PR TITLE
Extend tools to print information containers information

### DIFF
--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -12,6 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from bcc.libbcc import lib
+import ctypes as ct
+import os
+
+get_mntns_id_text = """
+    #ifndef __GET_MTN_NS_ID
+    #define __GET_MTN_NS_ID
+
+    #include <linux/nsproxy.h>
+    #include <linux/mount.h>
+    #include <linux/ns_common.h>
+
+    /* see mountsnoop.py:
+    * XXX: struct mnt_namespace is defined in fs/mount.h, which is private
+    * to the VFS and not installed in any kernel-devel packages. So, let's
+    * duplicate the important part of the definition. There are actually
+    * more members in the real struct, but we don't need them, and they're
+    * more likely to change.
+    */
+    struct mnt_namespace {
+    // This field was removed in https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+        atomic_t count;
+    #endif
+        struct ns_common ns;
+    };
+
+    static inline u64 get_mntns_id() {
+        struct task_struct *current_task;
+        current_task = (struct task_struct *)bpf_get_current_task();
+        return current_task->nsproxy->mnt_ns->ns.inum;
+    }
+    #endif // __GET_MTN_NS_ID
+    """
+
 def _cgroup_filter_func_writer(cgroupmap):
     if not cgroupmap:
         return """
@@ -38,32 +73,11 @@ def _mntns_filter_func_writer(mntnsmap):
             return 0;
         }
         """
-    text = """
-    #include <linux/nsproxy.h>
-    #include <linux/mount.h>
-    #include <linux/ns_common.h>
-
-    /* see mountsnoop.py:
-    * XXX: struct mnt_namespace is defined in fs/mount.h, which is private
-    * to the VFS and not installed in any kernel-devel packages. So, let's
-    * duplicate the important part of the definition. There are actually
-    * more members in the real struct, but we don't need them, and they're
-    * more likely to change.
-    */
-    struct mnt_namespace {
-    // This field was removed in https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13
-    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
-        atomic_t count;
-    #endif
-        struct ns_common ns;
-    };
-
+    text = get_mntns_id_text + """
     BPF_TABLE_PINNED("hash", u64, u32, mount_ns_set, 1024, "MOUNT_NS_PATH");
 
     static inline int _mntns_filter() {
-        struct task_struct *current_task;
-        current_task = (struct task_struct *)bpf_get_current_task();
-        u64 ns_id = current_task->nsproxy->mnt_ns->ns.inum;
+        u64 ns_id = get_mntns_id();
         return mount_ns_set.lookup(&ns_id) == NULL;
     }
     """
@@ -81,3 +95,53 @@ def filter_by_containers(args):
     mntnsmap_text = _mntns_filter_func_writer(args.mntnsmap)
 
     return cgroupmap_text + mntnsmap_text + filter_by_containers_text
+
+def print_container_info():
+    return """
+    #define PRINT_CONTAINER_INFO
+    """ + get_mntns_id_text
+
+# keep synchronized with definition in gadget tracer manager
+BUFFER_SIZE = 256
+
+class ContainerC(ct.Structure):
+    _fields_ = [
+        ("ContainerID", ct.c_char*BUFFER_SIZE ),
+        ("KubernetesNamespace", ct.c_char*BUFFER_SIZE),
+        ("KubernetesPod", ct.c_char*BUFFER_SIZE),
+        ("KubernetesContainer", ct.c_char*BUFFER_SIZE),
+    ]
+
+
+# get node name set by InspektorGadget to include in the output
+node_name = os.getenv("NODE_NAME", "<>")
+
+class Container:
+    def __init__(self):
+        self.Namespace = "<>"
+        self.PodName = "<>"
+        self.ContainerName = "<>"
+        self.NodeName = node_name
+
+class ContainersMap:
+    def __init__(self, map_path):
+        map_fd = lib.bpf_obj_get(map_path)
+        if int(map_fd) == -1:
+            raise Exception("error opening map")
+        self.map_fd = map_fd
+
+    # Get the details of the container from the containers map.
+    def get_container(self, mntnsid):
+        key = ct.c_ulonglong(mntnsid)
+        containerC = ContainerC()
+        container = Container()
+
+        ret = lib.bpf_lookup_elem(self.map_fd, ct.byref(key), ct.byref(containerC))
+        if int(ret) != 0:
+            return container
+
+        container.Namespace = containerC.KubernetesNamespace
+        container.PodName = containerC.KubernetesPod
+        container.ContainerName = containerC.KubernetesContainer
+
+        return container


### PR DESCRIPTION
This PR extends the tools supported by Inspektor Gadget to print more information about the containers where the events happen. 

This logic uses an eBPF map that is created by the gadget tracer manager with all the information about the different containers running in the node. 

To be used with https://github.com/kinvolk/inspektor-gadget/pull/207. 