### PR TITLE
Extend libbpf-tools for Inspektor Gadget

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -17,6 +17,14 @@ WORKDIR /root/bcc
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
     ./scripts/build-deb.sh ${BUILD_TYPE}
 
+# libbpf-tools
+RUN apt-get -qq update && \
+    apt-get -y install build-essential libelf-dev libfl-dev clang-10 libcap-dev
+
+RUN cd /root/bcc/src/cc/libbpf/src/ && make
+RUN cd /root/bcc/libbpf-tools/ && \
+  CLANG=clang-10 LLVM_STRIP=llvm-strip-10 make -j $(nproc) DESTDIR=/libbpf-tools/ prefix="" install
+
 FROM ubuntu:${OS_TAG}
 
 COPY --from=builder /root/bcc/*.deb /root/bcc/
@@ -30,3 +38,6 @@ RUN \
   fi ; \
   pip3 install dnslib cachetools  && \
   dpkg -i /root/bcc/*.deb
+
+# libbpf-tools
+COPY --from=builder /libbpf-tools/bin/* /bin/libbpf-tools/

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -60,6 +60,7 @@ COMMON_OBJ = \
 	$(OUTPUT)/errno_helpers.o \
 	$(OUTPUT)/map_helpers.o \
 	$(OUTPUT)/uprobe_helpers.o \
+	$(OUTPUT)/containers.o \
 	#
 
 .PHONY: all

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -18,11 +18,13 @@
 #include <bpf/bpf.h>
 #include "bindsnoop.h"
 #include "bindsnoop.skel.h"
+#include "containers.h"
 #include "trace_helpers.h"
 
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
 #define warn(...) fprintf(stderr, __VA_ARGS__)
+#define CONTAINERS_MAP_KEY 260
 
 static volatile sig_atomic_t exiting = 0;
 
@@ -30,6 +32,9 @@ static bool emit_timestamp = false;
 static pid_t target_pid = 0;
 static bool ignore_errors = true;
 static char *target_ports = NULL;
+static char *mntnsmap = NULL;
+static char *containersmap = NULL;
+static int containers_map_fd = -1;
 
 const char *argp_program_version = "bindsnoop 0.1";
 const char *argp_program_bug_address =
@@ -58,6 +63,8 @@ static const struct argp_option opts[] = {
 	{ "failed", 'x', NULL, 0, "Include errors on output." },
 	{ "pid", 'p', "PID", 0, "Process ID to trace" },
 	{ "ports", 'P', "PORTS", 0, "Comma-separated list of ports to trace." },
+	{ "mntnsmap", 'm', "mountnspath", 0, "Trace mount namespaces in this BPF map only" },
+	{ "containersmap", CONTAINERS_MAP_KEY, "CONTAINERSMAP", 0, "Print additional information about containers using this map" },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
@@ -102,6 +109,12 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'h':
 		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
 		break;
+	case 'm':
+		mntnsmap = arg;
+		break;
+	case CONTAINERS_MAP_KEY:
+		containersmap = arg;
+		break;
 	default:
 		return ARGP_ERR_UNKNOWN;
 	}
@@ -122,6 +135,11 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	char opts[] = {'F', 'T', 'N', 'R', 'r', '\0'};
 	const char *proto;
 	int i = 0;
+
+	if (containersmap) {
+		struct container c = get_container_info(containers_map_fd, e->mntns_id);
+		printf("%-16s %-16s %-16s %-16s", c.node, c.kubernetes_namespace, c.kubernetes_pod, c.kubernetes_container);
+	}
 
 	if (emit_timestamp) {
 		time(&t);
@@ -189,10 +207,29 @@ int main(int argc, char **argv)
 	obj->rodata->ignore_errors = ignore_errors;
 	obj->rodata->filter_by_port = target_ports != NULL;
 
+	if (mntnsmap != NULL) {
+		obj->rodata->filter_by_mnt_ns = true;
+
+		/* TODO: is there a way to avoid creating this map? */
+		err = bpf_map__set_pin_path(obj->maps.mount_ns_set, mntnsmap);
+		if (err) {
+			fprintf(stderr, "failed to set pin path for mntnsmap\n");
+			goto cleanup;
+		}
+	}
+
 	err = bindsnoop_bpf__load(obj);
 	if (err) {
 		warn("failed to load BPF object: %d\n", err);
 		goto cleanup;
+	}
+
+	if (containersmap) {
+		containers_map_fd = bpf_obj_get(containersmap);
+		if (containers_map_fd < 0) {
+			fprintf(stderr, "failed to open containers map %s: %d\n", containersmap, err);
+			return 1;
+		}
 	}
 
 	if (target_ports) {
@@ -224,6 +261,10 @@ int main(int argc, char **argv)
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
 		warn("can't set signal handler: %s\n", strerror(-errno));
 		goto cleanup;
+	}
+
+	if (containersmap) {
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
 	}
 
 	if (emit_timestamp)

--- a/libbpf-tools/bindsnoop.h
+++ b/libbpf-tools/bindsnoop.h
@@ -9,6 +9,7 @@ struct bind_event {
 	__u64 ts_us;
 	__u32 pid;
 	__u32 bound_dev_if;
+	__u64 mntns_id;
 	int ret;
 	__u16 port;
 	__u8 opts;

--- a/libbpf-tools/containers.c
+++ b/libbpf-tools/containers.c
@@ -1,0 +1,19 @@
+#include "containers.h"
+
+#include <stdlib.h>
+#include <bpf/bpf.h>
+
+struct container get_container_info(int map_fd, uint64_t mtnnsid) {
+	struct container container = {
+		.kubernetes_namespace = "<>",
+		.kubernetes_pod = "<>",
+		.kubernetes_container = "<>",
+		.node = "<>"
+	};
+
+	bpf_map_lookup_elem(map_fd, &mtnnsid, &container);
+
+	strncpy(container.node, getenv("NODE_NAME"), NAME_MAX_LENGTH - 1);
+
+	return container;
+}

--- a/libbpf-tools/containers.h
+++ b/libbpf-tools/containers.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __CONTAINERS_H
+#define __CONTAINERS_H
+
+#include <stdint.h>
+
+#define MAX_CONTAINERS_PER_NODE 1024
+#define NAME_MAX_LENGTH 256
+
+struct container {
+	char container_id[NAME_MAX_LENGTH];
+	char kubernetes_namespace[NAME_MAX_LENGTH];
+	char kubernetes_pod[NAME_MAX_LENGTH];
+	char kubernetes_container[NAME_MAX_LENGTH];
+	// this field is not present in the containers map so it's added as the last one here
+	char node[NAME_MAX_LENGTH];
+};
+
+struct container get_container_info(int map_fd, uint64_t mtnnsid);
+
+#endif /* __CONTAINERS_H */

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
+#include "containers.h"
 #include "execsnoop.h"
 #include "execsnoop.skel.h"
 #include "trace_helpers.h"
@@ -16,6 +17,7 @@
 #define PERF_BUFFER_PAGES   64
 #define NSEC_PRECISION (NSEC_PER_SEC / 1000)
 #define MAX_ARGS_KEY 259
+#define CONTAINERS_MAP_KEY 260
 
 static struct env {
 	bool time;
@@ -28,12 +30,15 @@ static struct env {
 	bool print_uid;
 	bool verbose;
 	int max_args;
+	const char *mntnsmap;
+	const char *containersmap;
 } env = {
 	.max_args = DEFAULT_MAXARGS,
 	.uid = INVALID_UID
 };
 
 static struct timespec start_time;
+static int containers_map_fd;
 
 const char *argp_program_version = "execsnoop 0.1";
 const char *argp_program_bug_address =
@@ -67,6 +72,9 @@ static const struct argp_option opts[] = {
 	{ "max-args", MAX_ARGS_KEY, "MAX_ARGS", 0,
 		"maximum number of arguments parsed and displayed, defaults to 20" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ "mntnsmap", 'm', "mountnspath", 0, "Trace mount namespaces in this BPF map only" },
+	{ "containersmap", CONTAINERS_MAP_KEY, "CONTAINERSMAP", 0, "Print additional information about containers using this map" },
+	{ "json", 'j', NULL, 0, "Output using json format" },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
@@ -123,6 +131,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		env.max_args = max_args;
 		break;
+	case 'm':
+		env.mntnsmap = arg;
+		break;
+	case CONTAINERS_MAP_KEY:
+		env.containersmap = arg;
+		break;
+	case 'j':
+		fprintf(stderr, "--json is not supported\n");
+		return ENOSYS;
 	default:
 		return ARGP_ERR_UNKNOWN;
 	}
@@ -228,6 +245,11 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	tm = localtime(&t);
 	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
 
+	if (env.containersmap) {
+		struct container c = get_container_info(containers_map_fd, e->mntns_id);
+		printf("%-16s %-16s %-16s %-16s", c.node, c.kubernetes_namespace, c.kubernetes_pod, c.kubernetes_container);
+	}
+
 	if (env.time) {
 		printf("%-8s ", ts);
 	}
@@ -283,10 +305,29 @@ int main(int argc, char **argv)
 	obj->rodata->targ_uid = env.uid;
 	obj->rodata->max_args = env.max_args;
 
+	if (env.mntnsmap != NULL) {
+		obj->rodata->filter_by_mnt_ns = true;
+
+		/* TODO: is there a way to avoid creating this map? */
+		err = bpf_map__set_pin_path(obj->maps.mount_ns_set, env.mntnsmap);
+		if (err) {
+			fprintf(stderr, "failed to set pin path for mntnsmap\n");
+			goto cleanup;
+		}
+	}
+
 	err = execsnoop_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);
 		goto cleanup;
+	}
+
+	if (env.containersmap) {
+		containers_map_fd = bpf_obj_get(env.containersmap);
+		if (containers_map_fd < 0) {
+			fprintf(stderr, "failed to open containers map %s: %d\n", env.containersmap, err);
+			return 1;
+		}
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &start_time);
@@ -296,6 +337,9 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 	/* print headers */
+	if (env.containersmap) {
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+	}
 	if (env.time) {
 		printf("%-9s", "TIME");
 	}

--- a/libbpf-tools/execsnoop.h
+++ b/libbpf-tools/execsnoop.h
@@ -16,6 +16,7 @@ struct event {
 	pid_t pid;
 	pid_t ppid;
 	uid_t uid;
+	__u64 mntns_id;
 	int retval;
 	int args_count;
 	unsigned int args_size;

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Netflix
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
 #include "opensnoop.h"
 
 #define TASK_RUNNING	0
@@ -12,6 +13,7 @@ const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
 const volatile uid_t targ_uid = 0;
 const volatile bool targ_failed = false;
+const volatile bool filter_by_mnt_ns = false;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -26,6 +28,13 @@ struct {
 	__uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__uint(key_size, sizeof(u64));
+	__uint(value_size, sizeof(u32));
+} mount_ns_set SEC(".maps");
+
 static __always_inline bool valid_uid(uid_t uid) {
 	return uid != INVALID_UID;
 }
@@ -33,6 +42,8 @@ static __always_inline bool valid_uid(uid_t uid) {
 static __always_inline
 bool trace_allowed(u32 tgid, u32 pid)
 {
+	struct task_struct *task;
+	u64 mntns_id;
 	u32 uid;
 
 	/* filters */
@@ -46,6 +57,13 @@ bool trace_allowed(u32 tgid, u32 pid)
 			return false;
 		}
 	}
+
+	task = (struct task_struct*)bpf_get_current_task();
+	mntns_id = (u64) BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+
+	if (filter_by_mnt_ns && !bpf_map_lookup_elem(&mount_ns_set, &mntns_id))
+		return false;
+
 	return true;
 }
 
@@ -92,6 +110,8 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	struct args_t *ap;
 	int ret;
 	u32 pid = bpf_get_current_pid_tgid();
+	struct task_struct *task;
+	u64 mntns_id;
 
 	ap = bpf_map_lookup_elem(&start, &pid);
 	if (!ap)
@@ -100,6 +120,12 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	if (targ_failed && ret >= 0)
 		goto cleanup;	/* want failed only */
 
+	task = (struct task_struct*)bpf_get_current_task();
+	mntns_id = (u64) BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+
+	if (filter_by_mnt_ns && !bpf_map_lookup_elem(&mount_ns_set, &mntns_id))
+		return 0;
+
 	/* event data */
 	event.pid = bpf_get_current_pid_tgid() >> 32;
 	event.uid = bpf_get_current_uid_gid();
@@ -107,6 +133,7 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	bpf_probe_read_user_str(&event.fname, sizeof(event.fname), ap->fname);
 	event.flags = ap->flags;
 	event.ret = ret;
+	event.mntns_id = mntns_id;
 
 	/* emit event */
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
+#include "containers.h"
 #include "opensnoop.h"
 #include "opensnoop.skel.h"
 #include "trace_helpers.h"
@@ -28,6 +29,8 @@
 
 #define NSEC_PER_SEC		1000000000ULL
 
+#define CONTAINERS_MAP_KEY 260
+
 static struct env {
 	pid_t pid;
 	pid_t tid;
@@ -39,9 +42,13 @@ static struct env {
 	bool extended;
 	bool failed;
 	char *name;
+	const char *mntnsmap;
+	const char *containersmap;
 } env = {
 	.uid = INVALID_UID
 };
+
+static int containers_map_fd;
 
 const char *argp_program_version = "opensnoop 0.1";
 const char *argp_program_bug_address =
@@ -76,6 +83,9 @@ static const struct argp_option opts[] = {
 	{ "print-uid", 'U', NULL, 0, "Print UID"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
 	{ "failed", 'x', NULL, 0, "Failed opens only"},
+	{ "mntnsmap", 'm', "mountnspath", 0, "Trace mount namespaces in this BPF map only" },
+	{ "containersmap", CONTAINERS_MAP_KEY, "CONTAINERSMAP", 0, "Print additional information about containers using this map" },
+	{ "json", 'j', NULL, 0, "Output using json format" },
 	{},
 };
 
@@ -151,6 +161,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		errno = 0;
 		break;
+	case 'm':
+		env.mntnsmap = arg;
+		break;
+	case CONTAINERS_MAP_KEY:
+		env.containersmap = arg;
+		break;
+	case 'j':
+		fprintf(stderr, "--json is not supported\n");
+		return ENOSYS;
 	default:
 		return ARGP_ERR_UNKNOWN;
 	}
@@ -190,6 +209,10 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	}
 
 	/* print output */
+	if (env.containersmap) {
+		struct container c = get_container_info(containers_map_fd, e->mntns_id);
+		printf("%-16s %-16s %-16s %-16s", c.node, c.kubernetes_namespace, c.kubernetes_pod, c.kubernetes_container);
+	}
 	if (env.timestamp)
 		printf("%-8s ", ts);
 	if (env.print_uid)
@@ -242,6 +265,17 @@ int main(int argc, char **argv)
 	obj->rodata->targ_uid = env.uid;
 	obj->rodata->targ_failed = env.failed;
 
+	if (env.mntnsmap != NULL) {
+		obj->rodata->filter_by_mnt_ns = true;
+
+		/* TODO: is there a way to avoid creating this map? */
+		err = bpf_map__set_pin_path(obj->maps.mount_ns_set, env.mntnsmap);
+		if (err) {
+			fprintf(stderr, "failed to set pin path for mntnsmap\n");
+			goto cleanup;
+		}
+	}
+
 #ifdef __aarch64__
 	/* aarch64 has no open syscall, only openat variants.
 	 * Disable associated tracepoints that do not exist. See #3344.
@@ -258,6 +292,14 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (env.containersmap) {
+		containers_map_fd = bpf_obj_get(env.containersmap);
+		if (containers_map_fd < 0) {
+			fprintf(stderr, "failed to open containers map %s: %d\n", env.containersmap, err);
+			return 1;
+		}
+	}
+
 	err = opensnoop_bpf__attach(obj);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs\n");
@@ -265,6 +307,9 @@ int main(int argc, char **argv)
 	}
 
 	/* print headers */
+	if (env.containersmap) {
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+	}
 	if (env.timestamp)
 		printf("%-8s ", "TIME");
 	if (env.print_uid)

--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -16,6 +16,7 @@ struct event {
 	__u64 ts;
 	pid_t pid;
 	uid_t uid;
+	__u64 mntns_id;
 	int ret;
 	int flags;
 	char comm[TASK_COMM_LEN];

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -10,12 +10,17 @@
 #include <unistd.h>
 #include <time.h>
 #include <bpf/bpf.h>
+#include "containers.h"
 #include "tcpconnect.h"
 #include "tcpconnect.skel.h"
 #include "trace_helpers.h"
 #include "map_helpers.h"
 
 #define warn(...) fprintf(stderr, __VA_ARGS__)
+
+#define CONTAINERS_MAP_KEY 260
+
+static int containers_map_fd;
 
 const char *argp_program_version = "tcpconnect 0.1";
 const char *argp_program_bug_address =
@@ -110,7 +115,9 @@ static const struct argp_option opts[] = {
 	{ "port", 'P', "PORTS", 0,
 	  "Comma-separated list of destination ports to trace" },
 	{ "cgroupmap", 'C', "PATH", 0, "trace cgroups in this map" },
-	{ "mntnsmap", 'M', "PATH", 0, "trace mount namespaces in this map" },
+	{ "mntnsmap", 'm', "PATH", 0, "Trace mount namespaces in this BPF map only" },
+	{ "containersmap", CONTAINERS_MAP_KEY, "CONTAINERSMAP", 0, "Print additional information about containers using this map" },
+	{ "json", 'j', NULL, 0, "Output using json format" },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
@@ -124,6 +131,8 @@ static struct env {
 	uid_t uid;
 	int nports;
 	int ports[MAX_PORTS];
+	const char *mntnsmap;
+	const char *containersmap;
 } env = {
 	.uid = (uid_t) -1,
 };
@@ -175,9 +184,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'C':
 		warn("not implemented: --cgroupmap");
 		break;
-	case 'M':
-		warn("not implemented: --mntnsmap");
+	case 'm':
+		env.mntnsmap = arg;
 		break;
+	case CONTAINERS_MAP_KEY:
+		env.containersmap = arg;
+		break;
+	case 'j':
+		fprintf(stderr, "--json is not supported\n");
+		return ENOSYS;
 	default:
 		return ARGP_ERR_UNKNOWN;
 	}
@@ -271,6 +286,8 @@ static void print_count(int map_fd_ipv4, int map_fd_ipv6)
 
 static void print_events_header()
 {
+	if (env.containersmap)
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
 	if (env.print_timestamp)
 		printf("%-9s", "TIME(s)");
 	if (env.print_uid)
@@ -299,6 +316,11 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	} else {
 		warn("broken event: event->af=%d", event->af);
 		return;
+	}
+
+	if (env.containersmap) {
+		struct container c = get_container_info(containers_map_fd, event->mntns_id);
+		printf("%-16s %-16s %-16s %-16s", c.node, c.kubernetes_namespace, c.kubernetes_pod, c.kubernetes_container);
 	}
 
 	if (env.print_timestamp) {
@@ -395,10 +417,29 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (env.mntnsmap != NULL) {
+		obj->rodata->filter_by_mnt_ns = true;
+
+		/* TODO: is there a way to avoid creating this map? */
+		err = bpf_map__set_pin_path(obj->maps.mount_ns_set, env.mntnsmap);
+		if (err) {
+			fprintf(stderr, "failed to set pin path for mntnsmap\n");
+			goto cleanup;
+		}
+	}
+
 	err = tcpconnect_bpf__load(obj);
 	if (err) {
 		warn("failed to load BPF object: %d\n", err);
 		goto cleanup;
+	}
+
+	if (env.containersmap) {
+		containers_map_fd = bpf_obj_get(env.containersmap);
+		if (containers_map_fd < 0) {
+			fprintf(stderr, "failed to open containers map %s: %d\n", env.containersmap, err);
+			return 1;
+		}
 	}
 
 	err = tcpconnect_bpf__attach(obj);

--- a/libbpf-tools/tcpconnect.h
+++ b/libbpf-tools/tcpconnect.h
@@ -38,6 +38,7 @@ struct event {
 	__u32 pid;
 	__u32 uid;
 	__u16 dport;
+	__u64 mntns_id;
 };
 
 #endif /* __TCPCONNECT_H */


### PR DESCRIPTION
This PR is a POC to make it possible to libbpf-based tools with Inspektor Gadget

The changes in this PR are:
- Extend execsnoop to be able to filter by container and print container info
- Package libbpf-tool in the BCC container image 

TODO
- [x] It's not clear how to handle the different docker images. Currently 3 versions are pushed: core, standard and gadget that combines the first two. 
- [x] Extend other tools used in Inspektor Gadget
- [ ] Implement --json support? 