### PR TITLE
Btf hub poc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/cc/libbpf"]
 	path = src/cc/libbpf
-	url = https://github.com/libbpf/libbpf.git
+	url = https://github.com/kinvolk/libbpf.git


### PR DESCRIPTION
This commit changes the libbpf dependency to load the BTF info also from /vmlinux.btf. This file is created by Inspektor Gadget when the kernel doesn't have BTF debug info available. 

Merge only after https://github.com/kinvolk/bcc/pull/5