### PR TITLE
Add --containersmap and --json support to mountsnoop

### DIFF
--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
 	}
 
 	if (containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 
 	if (emit_timestamp)

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
 	}
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.time) {
 		printf("%-9s", "TIME");

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
 
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.timestamp)
 		printf("%-8s ", "TIME");

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -287,7 +287,7 @@ static void print_count(int map_fd_ipv4, int map_fd_ipv6)
 static void print_events_header()
 {
 	if (env.containersmap)
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	if (env.print_timestamp)
 		printf("%-9s", "TIME(s)");
 	if (env.print_uid)

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -136,9 +136,9 @@ BUFFER_SIZE = 256
 class ContainerC(ct.Structure):
     _fields_ = [
         ("ContainerID", ct.c_char*BUFFER_SIZE ),
-        ("KubernetesNamespace", ct.c_char*BUFFER_SIZE),
-        ("KubernetesPod", ct.c_char*BUFFER_SIZE),
-        ("KubernetesContainer", ct.c_char*BUFFER_SIZE),
+        ("Namespace", ct.c_char*BUFFER_SIZE),
+        ("Pod", ct.c_char*BUFFER_SIZE),
+        ("Container", ct.c_char*BUFFER_SIZE),
     ]
 
 
@@ -169,16 +169,16 @@ class ContainersMap:
         if int(ret) != 0:
             return container
 
-        container.Namespace = containerC.KubernetesNamespace
-        container.PodName = containerC.KubernetesPod
-        container.ContainerName = containerC.KubernetesContainer
+        container.Namespace = containerC.Namespace
+        container.PodName = containerC.Pod
+        container.ContainerName = containerC.Container
 
         return container
 
     def enrich_json_event(self, eventJ, mntnsid):
         container = self.get_container(mntnsid)
 
-        eventJ["node_name"] = container.NodeName
-        eventJ["pod_name"] = container.PodName
-        eventJ["container_name"] = container.ContainerName
+        eventJ["node"] = container.NodeName
+        eventJ["pod"] = container.PodName
+        eventJ["container"] = container.ContainerName
         eventJ["namespace"] = container.Namespace

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -551,7 +551,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s " % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -262,7 +262,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 
 if args.extra:
     print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %-6s %s" % (

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -252,7 +252,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.time:
     print("%-9s" % ("TIME"), end="")
 if args.timestamp:

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -14,9 +14,11 @@ from __future__ import print_function
 import argparse
 import bcc
 from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.utils import disable_stdout
 import ctypes
 import errno
 import functools
+import json
 import sys
 
 
@@ -368,7 +370,7 @@ else:
         return '"{}"'.format(''.join(escape_character(c) for c in s))
 
 
-def print_event(mounts, umounts, containers_map, parent, cpu, data, size):
+def print_event(mounts, umounts, containers_map, stdout, parent, cpu, data, size):
     event = ctypes.cast(data, ctypes.POINTER(Event)).contents
 
     try:
@@ -440,6 +442,15 @@ def print_event(mounts, umounts, containers_map, parent, cpu, data, size):
                 print('{:16} {:<7} {:<7} {:<11} {}'.format(
                     syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
                     syscall['pid'], syscall['mnt_ns'], call))
+
+            if stdout:
+                eventJ = syscall
+
+                if containers_map:
+                    containers_map.enrich_json_event(eventJ, event.mntnsid)
+
+                json.dump(eventJ, stdout)
+                stdout.write("\n")
     except KeyError:
         # This might happen if we lost an event.
         pass
@@ -459,6 +470,8 @@ def main():
         help="trace mount namespaces in this BPF map only")
     parser.add_argument("--containersmap",
         help="print additional information about the containers where the events are executed")
+    parser.add_argument("--json", action="store_true",
+        help="output the events in json format")
     args = parser.parse_args()
 
     mounts = {}
@@ -473,6 +486,12 @@ def main():
     if args.ebpf:
         print(bpf_text)
         exit()
+
+    stdout = None
+    # disable sys.stdout when --json is passed
+    if args.json:
+        stdout, _ = disable_stdout()
+
     b = bcc.BPF(text=bpf_text)
     mount_fnname = b.get_syscall_fnname("mount")
     b.attach_kprobe(event=mount_fnname, fn_name="syscall__mount")
@@ -481,7 +500,7 @@ def main():
     b.attach_kprobe(event=umount_fnname, fn_name="syscall__umount")
     b.attach_kretprobe(event=umount_fnname, fn_name="do_ret_sys_umount")
     b['events'].open_perf_buffer(
-        functools.partial(print_event, mounts, umounts, containers_map, args.parent_process))
+        functools.partial(print_event, mounts, umounts, containers_map, stdout, args.parent_process))
 
     if args.containersmap:
         print("{:16} {:16} {:16} {:16}".format(

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -13,7 +13,7 @@
 from __future__ import print_function
 import argparse
 import bcc
-from bcc.containers import filter_by_containers
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info
 import ctypes
 import errno
 import functools
@@ -61,7 +61,7 @@ struct mnt_namespace {
  * argument as we can. Our stack space is limited, and we need to leave some
  * headroom for the rest of the function, so this should be a decent value.
  */
-#define MAX_STR_LEN 412
+#define MAX_STR_LEN 404
 
 enum event_type {
     EVENT_MOUNT,
@@ -96,6 +96,9 @@ struct data_t {
         /* EVENT_MOUNT_RET, EVENT_UMOUNT_RET */
         int retval;
     };
+#ifdef PRINT_CONTAINER_INFO
+    u64 mntnsid;
+#endif
 };
 
 BPF_PERF_OUTPUT(events);
@@ -158,6 +161,9 @@ int do_ret_sys_mount(struct pt_regs *ctx)
     event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
     event.tgid = bpf_get_current_pid_tgid() >> 32;
     event.retval = PT_REGS_RC(ctx);
+#ifdef PRINT_CONTAINER_INFO
+    event.mntnsid = get_mntns_id();
+#endif
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;
@@ -204,6 +210,9 @@ int do_ret_sys_umount(struct pt_regs *ctx)
     event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
     event.tgid = bpf_get_current_pid_tgid() >> 32;
     event.retval = PT_REGS_RC(ctx);
+#ifdef PRINT_CONTAINER_INFO
+    event.mntnsid = get_mntns_id();
+#endif
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;
@@ -250,7 +259,7 @@ UMOUNT_FLAGS = [
 
 
 TASK_COMM_LEN = 16  # linux/sched.h
-MAX_STR_LEN = 412
+MAX_STR_LEN = 404
 
 
 class EventType(object):
@@ -289,6 +298,7 @@ class Event(ctypes.Structure):
         ('pid', ctypes.c_uint),
         ('tgid', ctypes.c_uint),
         ('union', DataUnion),
+        ('mntnsid', ctypes.c_ulonglong),
     ]
 
 
@@ -358,7 +368,7 @@ else:
         return '"{}"'.format(''.join(escape_character(c) for c in s))
 
 
-def print_event(mounts, umounts, parent, cpu, data, size):
+def print_event(mounts, umounts, containers_map, parent, cpu, data, size):
     event = ctypes.cast(data, ctypes.POINTER(Event)).contents
 
     try:
@@ -371,6 +381,7 @@ def print_event(mounts, umounts, parent, cpu, data, size):
                 'flags': event.union.enter.flags,
                 'ppid': event.union.enter.ppid,
                 'pcomm': event.union.enter.pcomm,
+                'mntnsid': event.mntnsid,
             }
         elif event.type == EventType.EVENT_MOUNT_SOURCE:
             mounts[event.pid]['source'] = event.union.str
@@ -390,6 +401,7 @@ def print_event(mounts, umounts, parent, cpu, data, size):
                 'flags': event.union.enter.flags,
                 'ppid': event.union.enter.ppid,
                 'pcomm': event.union.enter.pcomm,
+                'mntnsid': event.mntnsid,
             }
         elif event.type == EventType.EVENT_UMOUNT_TARGET:
             umounts[event.pid]['target'] = event.union.str
@@ -411,6 +423,14 @@ def print_event(mounts, umounts, parent, cpu, data, size):
                     target=decode_mount_string(syscall['target']),
                     flags=decode_umount_flags(syscall['flags']),
                     retval=decode_errno(event.union.retval))
+
+            if containers_map:
+                container = containers_map.get_container(event.mntnsid)
+
+                print('{:16} {:16} {:16} {:16}'.format(
+                    container.NodeName, container.Namespace, container.PodName,
+                    container.ContainerName), end='')
+
             if parent:
                 print('{:16} {:<7} {:<7} {:16} {:<7} {:<11} {}'.format(
                     syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
@@ -437,12 +457,19 @@ def main():
         help="trace cgroups in this BPF map only")
     parser.add_argument("--mntnsmap",
         help="trace mount namespaces in this BPF map only")
+    parser.add_argument("--containersmap",
+        help="print additional information about the containers where the events are executed")
     args = parser.parse_args()
 
     mounts = {}
     umounts = {}
     global bpf_text
     bpf_text = filter_by_containers(args) + bpf_text
+
+    containers_map = None
+    if args.containersmap:
+        bpf_text = print_container_info() + bpf_text
+        containers_map = ContainersMap(args.containersmap)
     if args.ebpf:
         print(bpf_text)
         exit()
@@ -454,7 +481,11 @@ def main():
     b.attach_kprobe(event=umount_fnname, fn_name="syscall__umount")
     b.attach_kretprobe(event=umount_fnname, fn_name="do_ret_sys_umount")
     b['events'].open_perf_buffer(
-        functools.partial(print_event, mounts, umounts, args.parent_process))
+        functools.partial(print_event, mounts, umounts, containers_map, args.parent_process))
+
+    if args.containersmap:
+        print("{:16} {:16} {:16} {:16}".format(
+              'NODE', 'NAMESPACE', 'PODNAME', 'CONTAINERNAME'), end='')
 
     if args.parent_process:
         print('{:16} {:<7} {:<7} {:16} {:<7} {:<11} {}'.format(

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -357,7 +357,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
 if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -190,7 +190,7 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
     u16 dport = skp->__sk_common.skc_dport;
 
     FILTER_PORT
-    
+
     FILTER_FAMILY
 
     if (ipver == 4) {
@@ -585,7 +585,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -729,7 +729,7 @@ print("Tracing TCP established connections. Ctrl-C to end.")
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.verbose:
     if args.timestamp:
         print("%-14s" % ("TIME(ns)"), end="")


### PR DESCRIPTION
Hi.


In this PR, I added two commits:
1. The first one bring supports to `--containersmap` argument, so namespace and pod name are printed:
```bash
you@home$ ./kubectl-gadget-linux-amd64 -n kube-system mountsnoop
NODE             NAMESPACE        PODNAME          CONTAINERNAME   COMM             PID     TID     MNT_NS      CALL
minikube         kube-system      gadget-zzqj4     gadget          mount            171473  171473  4026532442  mount("/mnt", "/mnt", "ext3", MS_MGC_VAL|MS_SILENT, "") = -ENOTBLK
```
2. The other enables output to be printed to JSON:
```bash
you@home$ ./kubectl-gadget-linux-amd64 -n kube-system mountsnoop --json | jq
{
  "pcomm": "bash",
  "pid": 172919,
  "comm": "mount",
  "pod_name": "gadget-zzqj4",
  "container_name": "gadget",
  "data": "",
  "mnt_ns": 4026532442,
  "target": "/mnt",
  "tgid": 172919,
  "namespace": "kube-system",
  "node_name": "minikube",
  "source": "/mnt",
  "flags": 3236790272,
  "mntnsid": 0,
  "ppid": 171427,
  "type": "ext3"
}
```

If you see any way to improve this PR, feel free to share it!


Best regards.