### PR TITLE
Add function to print containersmap header

### DIFF
--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
 	}
 
 	if (containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 
 	if (emit_timestamp)

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
 	}
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.time) {
 		printf("%-9s", "TIME");

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
 
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.timestamp)
 		printf("%-8s ", "TIME");

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -287,7 +287,7 @@ static void print_count(int map_fd_ipv4, int map_fd_ipv6)
 static void print_events_header()
 {
 	if (env.containersmap)
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	if (env.print_timestamp)
 		printf("%-9s", "TIME(s)");
 	if (env.print_uid)

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -136,9 +136,9 @@ BUFFER_SIZE = 256
 class ContainerC(ct.Structure):
     _fields_ = [
         ("ContainerID", ct.c_char*BUFFER_SIZE ),
-        ("KubernetesNamespace", ct.c_char*BUFFER_SIZE),
-        ("KubernetesPod", ct.c_char*BUFFER_SIZE),
-        ("KubernetesContainer", ct.c_char*BUFFER_SIZE),
+        ("Namespace", ct.c_char*BUFFER_SIZE),
+        ("Pod", ct.c_char*BUFFER_SIZE),
+        ("Container", ct.c_char*BUFFER_SIZE),
     ]
 
 
@@ -169,16 +169,16 @@ class ContainersMap:
         if int(ret) != 0:
             return container
 
-        container.Namespace = containerC.KubernetesNamespace
-        container.PodName = containerC.KubernetesPod
-        container.ContainerName = containerC.KubernetesContainer
+        container.Namespace = containerC.Namespace
+        container.PodName = containerC.Pod
+        container.ContainerName = containerC.Container
 
         return container
 
     def enrich_json_event(self, eventJ, mntnsid):
         container = self.get_container(mntnsid)
 
-        eventJ["node_name"] = container.NodeName
-        eventJ["pod_name"] = container.PodName
-        eventJ["container_name"] = container.ContainerName
+        eventJ["node"] = container.NodeName
+        eventJ["pod"] = container.PodName
+        eventJ["container"] = container.ContainerName
         eventJ["namespace"] = container.Namespace

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -133,6 +133,14 @@ def print_container_info():
 # keep synchronized with definition in gadget tracer manager
 BUFFER_SIZE = 256
 
+NODE_HEADER = "NODE";
+NAMESPACE_HEADER = "NAMESPACE";
+POD_HEADER = "POD";
+CONTAINER_HEADER = "CONTAINER";
+
+def print_additional_info_header():
+	print('{:16} {:16} {:16} {:16}'.format(NODE_HEADER, NAMESPACE_HEADER, POD_HEADER, CONTAINER_HEADER), end = '')
+
 class ContainerC(ct.Structure):
     _fields_ = [
         ("ContainerID", ct.c_char*BUFFER_SIZE ),

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -551,7 +551,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s " % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -28,7 +28,7 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 from bcc import BPF, DEBUG_SOURCE
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -551,7 +551,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+        print_additional_info_header()
     if args.timestamp:
         print("%-9s " % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -262,7 +262,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 
 if args.extra:
     print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %-6s %s" % (

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 from os import getpid
 from functools import partial
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import disable_stdout
 import errno
 import argparse
@@ -262,7 +262,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 
 if args.extra:
     print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %-6s %s" % (

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -252,7 +252,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.time:
     print("%-9s" % ("TIME"), end="")
 if args.timestamp:

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -17,7 +17,7 @@
 
 from __future__ import print_function
 from bcc import ArgString, BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -357,7 +357,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
 if args.print_uid:

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -357,7 +357,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
 if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -23,7 +23,7 @@
 
 from __future__ import print_function
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -585,7 +585,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+        print_additional_info_header()
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -190,7 +190,7 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
     u16 dport = skp->__sk_common.skc_dport;
 
     FILTER_PORT
-    
+
     FILTER_FAMILY
 
     if (ipver == 4) {
@@ -585,7 +585,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -729,7 +729,7 @@ print("Tracing TCP established connections. Ctrl-C to end.")
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.verbose:
     if args.timestamp:
         print("%-14s" % ("TIME(ns)"), end="")

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -16,7 +16,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 from __future__ import print_function
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import disable_stdout
 
 import argparse as ap
@@ -729,7 +729,7 @@ print("Tracing TCP established connections. Ctrl-C to end.")
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 if args.verbose:
     if args.timestamp:
         print("%-14s" % ("TIME(ns)"), end="")


### PR DESCRIPTION
Hi.


In this PR, I added `print_additional_info_header` which basically prints:
```
NODE             NAMESPACE        POD          CONTAINER
```
when `--containersmap` is used.
It makes the code easier to change, as now if we want to modify header name, we just need to modify corresponding values in `containers.py`.


Best regards.