### PR TITLE
libbpf-tools/mountsnoop: Extend for inspektor gadget.

### DIFF
--- a/libbpf-tools/mountsnoop.bpf.c
+++ b/libbpf-tools/mountsnoop.bpf.c
@@ -9,6 +9,7 @@
 #define MAX_ENTRIES 10240
 
 const volatile pid_t target_pid = 0;
+const volatile bool filter_by_mnt_ns = false;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -29,6 +30,13 @@ struct {
 	__uint(key_size, sizeof(__u32));
 	__uint(value_size, sizeof(__u32));
 } events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__uint(key_size, sizeof(u64));
+	__uint(value_size, sizeof(u32));
+} mount_ns_set SEC(".maps");
 
 static int probe_entry(const char *src, const char *dest, const char *fs,
 		       __u64 flags, const char *data, enum op op)
@@ -61,6 +69,13 @@ static int probe_exit(void *ctx, int ret)
 	struct event *eventp;
 	struct task_struct *task;
 	int zero = 0;
+	u64 mntns_id;
+
+	task = (struct task_struct*) bpf_get_current_task();
+	mntns_id = (u64) BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+
+	if (filter_by_mnt_ns && !bpf_map_lookup_elem(&mount_ns_set, &mntns_id))
+		return 0;
 
 	argp = bpf_map_lookup_elem(&args, &tid);
 	if (!argp)
@@ -70,12 +85,11 @@ static int probe_exit(void *ctx, int ret)
 	if (!eventp)
 		return 0;
 
-	task = (struct task_struct *)bpf_get_current_task();
 	eventp->delta = bpf_ktime_get_ns() - argp->ts;
 	eventp->flags = argp->flags;
 	eventp->pid = pid;
 	eventp->tid = tid;
-	eventp->mnt_ns = BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+	eventp->mnt_ns = (unsigned int) mntns_id;
 	eventp->ret = ret;
 	eventp->op = argp->op;
 	bpf_get_current_comm(&eventp->comm, sizeof(eventp->comm));


### PR DESCRIPTION
Hi.


With this commit, you can now execute C version of `mountsnoop` from `inspektor-gadget`:
```bash
you@home ./kubectl-gadget mountsnoop -n kube-system
NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL
kind-control-plane kube-system      gadget-t5ptj     gadget           mount            331215  331215  4026534185  mount("/mnt", "/mnt", "btrfs", MS_SILENT | MS_POSIXACL | MS_PRIVATE | MS_SLAVE | MS_RELATIME | MS_KERNMOUNT | MS_I_VERSION | MS_ACTIVE | MS_NOUSER, "") = -15
kind-control-plane kube-system      kube-proxy-948cc kube-proxy       mount            335794  335794  4026533498  mount("/mnt", "/mnt", "btrfs", MS_SILENT, "") = -15
^C
Terminating...
you@home kubectl exec -ti -n kube-system gadget-t5ptj -- bash -c 'echo $INSPEKTOR_GADGET_OPTION_TOOLS_MODE'
core
```


Best regards.