### PR TITLE
libbpf-tools: Add .bpf.o files to container image

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -41,3 +41,4 @@ RUN \
 
 # libbpf-tools
 COPY --from=builder /libbpf-tools/bin/* /bin/libbpf-tools/
+COPY --from=builder /root/bcc/libbpf-tools/.output/*.bpf.o /objs/


### PR DESCRIPTION
Add those files that will be used later on with BTFGen
