### PR TITLE
GHA: disable build for bionic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: bionic-release
-          OS_RELEASE: 18.04
+        #- NAME: bionic-release
+        #  OS_RELEASE: 18.04
         - NAME: focal-release
           OS_RELEASE: 20.04
     steps:
@@ -106,6 +106,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         workdir: .
-        dockerfile: Dockerfile.ubuntu
+        dockerfile: docker/Dockerfile.ubuntu
         snapshot: true
         cache: ${{ github.event_name != 'schedule' }}
+        buildargs: ARG OS_TAG=20.04


### PR DESCRIPTION
It's failing, so disable it. IG only uses the focal one so we're all good.
