### PR TITLE
Print kernel headers messages to standard error

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -188,9 +188,9 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     if (!ret) {
       kpath = tmpdir;
     } else {
-      std::cout << "Unable to find kernel headers. ";
-      std::cout << "Try rebuilding kernel with CONFIG_IKHEADERS=m (module) ";
-      std::cout <<  "or installing the kernel development package for your running kernel version.\n";
+      std::cerr << "Unable to find kernel headers. ";
+      std::cerr << "Try rebuilding kernel with CONFIG_IKHEADERS=m (module) ";
+      std::cerr <<  "or installing the kernel development package for your running kernel version.\n";
     }
   }
 


### PR DESCRIPTION
Hi.


In this PR, I printed the error messages related to lack of kernel headers on standard error instead of standard output.
By doing so, we will avoid error message like:

```
failed to unmarshal event: invalid character 'U' looking for beginning of value
```

Due to this error message:

```
Unable to find kernel headers. Try rebuilding kernel with CONFIG_IKHEADERS=m (module) or installing the kernel devel
```

(The 'U' in the first message is the first letter at the beginning of the second).


Best regards.