### PR TITLE
tools/bindsnoop: Fix bug when using --json and IPv6

### DIFF
--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -442,12 +442,13 @@ def print_json(event, inetType):
     # always print timestamp
     if start_ts == 0:
             start_ts = event.ts_us
+    saddr = event.saddr if inetType == AF_INET6 else pack("I", event.saddr)
     eventJ = {
         "time": ((float(event.ts_us) - start_ts) / 1000000),
         "uid": event.uid,
         "pid": event.pid,
         "comm": event.task,
-        "addr": inet_ntop(inetType, pack("I", event.saddr)).encode(),
+        "addr": inet_ntop(inetType, saddr),
         "proto": l4.proto2str(event.protocol).encode(),
         "port": event.sport,
         "opts": opts2array(event.socket_options),


### PR DESCRIPTION
Follow the same structure as in other places and do not use pack() when
the address is an IPv6.

Before:

```bash
$ /usr/share/bcc/tools/bindsnoop --json
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 315, in 'calling callback function'
  File "/usr/lib/python2.7/dist-packages/bcc/table.py", line 982, in raw_cb_
    callback(cpu, data, size)
  File "/usr/share/bcc/tools/bindsnoop", line 510, in print_ipv6_bind_event
    print_json(event, AF_INET6)
  File "/usr/share/bcc/tools/bindsnoop", line 450, in print_json
    "addr": inet_ntop(inetType, pack("I", event.saddr)).encode(),
struct.error: cannot convert argument to integer
```

now:

```bash
$ /usr/share/bcc/tools/bindsnoop --json
{"addr": "0.0.0.0", "comm": "nc", "uid": 1000, "time": 0.0, "proto": "UNKNOWN", "pid": 338304, "port": 5001, "opts": {"R": true, "N": false, "r": true, "T": false, "F": false}, "if": 0}
{"addr": "::", "comm": "nc", "uid": 1000, "time": 5.247888, "proto": "UNKNOWN", "pid": 338307, "port": 5001, "opts": {"R": true, "N": false, "r": true, "T": false, "F": false}, "if": 0}

```

