### PR TITLE
tools: Modify print_json_hist helper so JSON key are lowerCamelCase.

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -121,14 +121,14 @@ def _print_json_hist(vals, val_type, section_bucket=None):
             index = index * 2
 
             list_obj = {}
-            list_obj['interval-start'] = prev
-            list_obj['interval-end'] = int(index) - 1
+            list_obj['intervalStart'] = prev
+            list_obj['intervalEnd'] = int(index) - 1
             list_obj['count'] = int(vals[i])
 
             hist_list.append(list_obj)
 
             prev = index
-    histogram = {"ts": strftime("%Y-%m-%d %H:%M:%S"), "val_type": val_type, "data": hist_list}
+    histogram = {"ts": strftime("%Y-%m-%d %H:%M:%S"), "valType": val_type, "data": hist_list}
     if section_bucket:
         histogram[section_bucket[0]] = section_bucket[1]
     print(histogram)

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -326,7 +326,7 @@ def print_event(bpf, cpu, data, size):
             "comm": event.comm.decode('utf-8', 'replace'),
             "pid": event.pid,
             "cap": event.cap,
-            "cap_name": name,
+            "capName": name,
             "audit": event.audit,
             "insetid": str(event.insetid) if event.insetid != -1 else "N/A",
         }

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -378,8 +378,8 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
         report = {
             'comm': k.name,
             'pid': k.pid,
-            'user_stack': [] if stack_id_err(k.user_stack_id) else [b.sym(addr, k.pid) for addr in user_stack],
-            'kernel_stack': [] if stack_id_err(k.kernel_stack_id) else [aksym(addr) for addr in kernel_stack],
+            'userStack': [] if stack_id_err(k.user_stack_id) else [b.sym(addr, k.pid) for addr in user_stack],
+            'kernelStack': [] if stack_id_err(k.kernel_stack_id) else [aksym(addr) for addr in kernel_stack],
             'value': v.value,
         }
 


### PR DESCRIPTION
In Inspektor Gadget, we rename all our JSON key to use lowerCamelCase [1]. Sadly, this change was not propagated to our fork of iovisor/bcc for biolatency.

So, this commit modifies JSON key to use lowerCamelCase, then aligning with Inspektor Gadget.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>

[1] https://github.com/kinvolk/inspektor-gadget/commit/b062da5352df