### PR TITLE
ci: Trigger the pipeline to craft docker images each day at 6am.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Build Artifacts
 
 on:
+  schedule:
+    # Trigger the pipeline each day at 6am.
+    - cron:  '0 6 * * *'
   push:
     branches:
       - gadget


### PR DESCRIPTION
Hi.


In this PR, I added CI instruction to trigger the pipeline each day at 6am.
This would lead to our `kinvok/bcc` docker images to be updated more often and would avoid use having CVE.


Best regards.