### PR TITLE
Use focal as DEFAULT_RELEASE_TARGET when pushing container images.

### DIFF
--- a/scripts/docker/push.sh
+++ b/scripts/docker/push.sh
@@ -5,7 +5,7 @@ set -e
 # You must run login.sh before running this script.
 
 DEFAULT_DOCKER_REPO="quay.io"
-DEFAULT_RELEASE_TARGET="bionic-release" # will allow unprefixed tags
+DEFAULT_RELEASE_TARGET="focal-release" # will allow unprefixed tags
 
 # Currently only support pushing to quay.io
 DOCKER_REPO=${DEFAULT_DOCKER_REPO}


### PR DESCRIPTION
Hi.


In this PR, I modified the value of `DEFAULT_RELEASE_TARGET` from `bionic` to `focal`.
Indeed, we did not craft an image with `bionic` as the base.
Moreover, using `focal` there will lead to the `gadget` image to point to the latest image built for this branch.


Best regards.