### PR TITLE
ci: Add gadget tag to container image.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,11 @@ jobs:
         context: .
         file: docker/Dockerfile.ubuntu
         push: true
-        tags: quay.io/kinvolk/bcc:${{ github.sha }}-${{ matrix.env['NAME'] }}
+        tags:
+          - quay.io/kinvolk/bcc:${{ github.sha }}-${{ matrix.env['NAME'] }}
+          # We only use a matrix with one job, so it is fine to hardcode gadget
+          # here.
+          - gadget
         build-args: OS_TAG=${{ matrix.env['OS_RELEASE'] }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
```
On the gadget branch, we do not use the scripts to push to quay.io. So, we add the gadget tag to our CI job, then each time this branch is triggered the container image will be updated for this tag.

Fixes: 246b4f0cf397 ("Use focal as DEFAULT_RELEASE_TARGET when pushing container images.")
```