### PR TITLE
ci: Use quay.io/kinvolk/bcc:gadget rather gadget.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
         # here.
         tags: |
           quay.io/kinvolk/bcc:${{ github.sha }}-${{ matrix.env['NAME'] }}
-          gadget
+          quay.io/kinvolk/bcc:gadget
         build-args: OS_TAG=${{ matrix.env['OS_RELEASE'] }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
```
This docker action is cool, but it still not guess where I want to push the image...

Fixes: 9de67e239f48 ("ci: Use list context rather than itemize for container image tags.")
```