### PR TITLE
docker: Update pip and pre-installed packages.

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -29,4 +29,6 @@ RUN \
     pip install dnslib cachetools ; \
   fi ; \
   pip3 install dnslib cachetools  && \
+  pip3 install -U pip setuptools wheel && \
+  apt-get -y remove python3-pip && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
```
When building the docker image for Ubuntu 20.04, the distribution python3-pip comes with some pre-installed python packages which are out of date:
Package    Version
---------- -------
bcc        0.24.0
cachetools 5.3.0
dnslib     0.9.23
pip        20.0.2
setuptools 45.2.0
wheel      0.34.2
As a result, the wheel package is flawed with a CVE [1].

This commit updates the pre-installed packages as well as pip and removes the distribution pip.
So, the pre-installed packages no more suffer CVE:
Package    Version
---------- -------
bcc        0.24.0
cachetools 5.3.0
dnslib     0.9.23
pip        23.0.1
setuptools 67.6.0
wheel      0.40.0

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1] https://dso.docker.com/cve/CVE-2022-40898
```

There is already an upstream PR (iovisor/bcc#4528) but I would like to merge this soon.