### PR TITLE
docker: Remove python3 distribution packages.

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -30,5 +30,5 @@ RUN \
   fi ; \
   pip3 install dnslib cachetools  && \
   pip3 install -U pip setuptools wheel && \
-  apt-get -y remove python3-pip && \
+  apt-get -y remove python3-pip python3-wheel python3-setuptools && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
When building the docker image, we upgrade pip, setuptools and wheel using pip itself.
We then removed python3-pip.
Nonetheless, we forgot to remove python3-setuptools and python3-wheel, which leaded CVE scan to fail.

So, this commit removes these unused packages as we rely on the versions provided by pip.

Fixes: 6e8a441d3175 ("docker: Update pip and pre-installed packages.")
Reported-by: Steven Powell (https://github.com/kubernetes/minikube/pull/15869#issuecomment-1500454800)