### PR TITLE
docker: Use debian bookworm as final image

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,13 +30,6 @@ Architecture: any
 Depends: libbcc (= ${binary:Version})
 Description: Examples for BPF Compiler Collection (BCC)
 
-Package: python-bcc
-Architecture: all
-Provides: python-bpfcc
-Conflicts: python-bpfcc
-Depends: libbcc (= ${binary:Version}), python, binutils
-Description: Python wrappers for BPF Compiler Collection (BCC)
-
 Package: python3-bcc
 Architecture: all
 Provides: python3-bpfcc
@@ -48,7 +41,7 @@ Package: bcc-tools
 Architecture: all
 Provides: bpfcc-tools
 Conflicts: bpfcc-tools
-Depends: python-bcc (= ${binary:Version})
+Depends: python3-bcc (= ${binary:Version})
 Description: Command line tools for BPF Compiler Collection (BCC)
 
 Package: bcc-lua

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEBIAN_REVISION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)
 UPSTREAM_VERSION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)(~|-)(.*),\1,p")
 
 %:
-	dh $@ --buildsystem=cmake --parallel --with python2,python3
+	dh $@ --buildsystem=cmake --parallel --with python3
 
 # tests cannot be run in parallel
 override_dh_auto_test:
@@ -17,4 +17,4 @@ override_dh_auto_test:
 
 # FIXME: LLVM_DEFINITIONS is broken somehow in LLVM cmake upstream
 override_dh_auto_configure:
-	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python2;python3"
+	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python3"

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -17,18 +17,12 @@ WORKDIR /root/bcc
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
     ./scripts/build-deb.sh ${BUILD_TYPE}
 
-FROM ubuntu:${OS_TAG}
+FROM debian:bookworm
 
 COPY --from=builder /root/bcc/*.deb /root/bcc/
 
 RUN \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 python3-pip binutils libelf1 kmod  && \
-  if [ ${OS_TAG} = "18.04" ];then \
-    apt-get -y install python-pip && \
-    pip install dnslib cachetools ; \
-  fi ; \
-  pip3 install dnslib cachetools  && \
-  pip3 install -U pip setuptools wheel && \
-  apt-get -y remove python3-pip python3-wheel python3-setuptools && \
-  dpkg -i /root/bcc/*.deb
+  DEBIAN_FRONTEND=noninteractive apt-get install -y binutils kmod libelf1 libtinfo5 python3 xz-utils && \
+  dpkg -i /root/bcc/*.deb && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3 3


### PR DESCRIPTION
golang:1.19 was modified to use debian:bookworm as its base as bookworm is now the new stable [1, 2].
bookworm comes with GLIBC 2.36 which is indeed not compatible with GLIBC 2.31 shipped in bullseye [3, 4].
This leaded to impossibility of running the gadgettracermanager compiled on golang:1.19, so with GLIBC 2.36, and run in iovisor/bcc, i.e. ubuntu:focal which comes with GLIBC 2.31 too [5].

To solve this, this commit uses a different final image for iovisor/bcc. The debian packages will be built in ubuntu:focal but we will install them in debian:bookworm to ensure we have the GLIBC between build time and run time.

Note that, for unknown reason, we needed to install libtinfo5 because libbcc.so needs it.

[1]: https://www.debian.org/News/2023/20230610
[2]: https://github.com/docker-library/golang/commit/cd607138e461
[3]: https://packages.debian.org/source/bookworm/glibc
[4]: https://packages.debian.org/source/bullseye/glibc
[5]: https://packages.ubuntu.com/source/focal/glibc